### PR TITLE
Use feature detection instead of version detection

### DIFF
--- a/tensorflow_text/python/ops/string_ops.py
+++ b/tensorflow_text/python/ops/string_ops.py
@@ -19,15 +19,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import sys
-
 from tensorflow.python.ops import string_ops
 
 
 def _unichr(codepoint):
-  if sys.version_info[0] == 2:
+  try:
     return unichr(codepoint)
-  else:
+  except NameError:
     return chr(codepoint)
 
 


### PR DESCRIPTION
As discussed in #13, follow the Python porting best practice, [__use feature detection instead of version detection__](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).