### PR TITLE
WordpieceTokenizer: Add support for splitting unknown characters

### DIFF
--- a/tensorflow_text/core/kernels/wordpiece_kernel.cc
+++ b/tensorflow_text/core/kernels/wordpiece_kernel.cc
@@ -124,8 +124,7 @@ class LookupTableVocab : public WordpieceVocab {
  public:
   LookupTableVocab(lookup::LookupInterface* table, OpKernelContext* ctx);
 
-  virtual LookupStatus Contains(const absl::string_view key,
-                                bool* value) const;
+  virtual LookupStatus Contains(const absl::string_view key, bool* value) const;
 
  private:
   // not owned
@@ -189,8 +188,9 @@ class WordpieceTokenizeWithOffsetsOp : public OpKernel {
     } else if (output_row_partition_type == "row_splits") {
       row_partition_type_ = ROW_SPLITS;
     } else {
-      OP_REQUIRES(ctx, false, errors::Internal(
-          "Unexpected value for output_row_partition_type"));
+      OP_REQUIRES(
+          ctx, false,
+          errors::Internal("Unexpected value for output_row_partition_type"));
     }
   }
 
@@ -221,9 +221,8 @@ class WordpieceTokenizeWithOffsetsOp : public OpKernel {
           ctx, ToStatus(WordpieceTokenize(
                    values_vec(i), max_bytes_per_word_, max_chars_per_token_,
                    suffix_indicator_, use_unknown_token_, unknown_token_,
-                   split_unknown_characters_,
-                   &vocab_map, &subwords, &begin_offset, &end_offset,
-                   &num_wordpieces)));
+                   split_unknown_characters_, &vocab_map, &subwords,
+                   &begin_offset, &end_offset, &num_wordpieces)));
 
       // Record the row splits.
       switch (row_partition_type_) {

--- a/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
+++ b/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
@@ -49,8 +49,12 @@ LookupStatus Lookup(int byte_start, int byte_end,
 LookupStatus LongestMatchStartingAt(int byte_start,
                                     const absl::string_view& token,
                                     const std::string& suffix_indicator,
+                                    bool split_unknown_characters,
                                     const WordpieceVocab* vocab_map,
-                                    int* byte_end, bool* found_match) {
+                                    int* byte_end, bool* found_match,
+                                    bool* match_is_unknown_character) {
+  *match_is_unknown_character = false;
+  *found_match = false;
   const char* token_bytes = token.data();
   const int token_len = token.length();
   std::vector<int32_t> byte_ends;
@@ -70,8 +74,13 @@ LookupStatus LongestMatchStartingAt(int byte_start,
       *found_match = true;
       return LookupStatus::OK();
     }
+    if (i == 0 && split_unknown_characters) {
+      *byte_end = byte_ends[0];
+      *found_match = true;
+      *match_is_unknown_character = true;
+      return LookupStatus::OK();
+    }
   }
-  *found_match = false;
   return LookupStatus::OK();
 }
 
@@ -104,6 +113,7 @@ void AddWord(const absl::string_view& token, int byte_start, int byte_end,
              std::vector<int>* end_offset) {
   begin_offset->push_back(byte_start);
   int len = byte_end - byte_start;
+
   if (byte_start > 0) {
     // Prepend suffix_indicator if the token is within a word.
     subwords->push_back(::absl::StrCat(
@@ -114,12 +124,34 @@ void AddWord(const absl::string_view& token, int byte_start, int byte_end,
   end_offset->push_back(byte_end);
 }
 
+void AddUnknownCharacter(
+    const absl::string_view& token, int byte_start, int byte_end,
+    const std::string& suffix_indicator, bool use_unknown_token,
+    const std::string& unknown_token, std::vector<std::string>* subwords,
+    std::vector<int>* begin_offset, std::vector<int>* end_offset) {
+  begin_offset->push_back(byte_start);
+  end_offset->push_back(byte_end);
+  int len = byte_end - byte_start;
+  if (use_unknown_token) {
+    subwords->push_back(unknown_token);
+  } else {
+    if (byte_start > 0) {
+     // Prepend suffix_indicator if the token is within a word.
+     subwords->push_back(::absl::StrCat(
+         suffix_indicator, absl::string_view(token.data() + byte_start, len)));
+    } else {
+     subwords->emplace_back(token.data(), len);
+    }
+  }
+}
+
 LookupStatus TokenizeL2RGreedy(
     const absl::string_view& token, const int max_bytes_per_token,
     const std::string& suffix_indicator, bool use_unknown_token,
-    const std::string& unknown_token, const WordpieceVocab* vocab_map,
-    std::vector<std::string>* subwords, std::vector<int>* begin_offset,
-    std::vector<int>* end_offset, int* num_word_pieces) {
+    const std::string& unknown_token, bool split_unknown_characters,
+    const WordpieceVocab* vocab_map, std::vector<std::string>* subwords,
+    std::vector<int>* begin_offset, std::vector<int>* end_offset,
+    int* num_word_pieces) {
   std::vector<std::string> candidate_subwords;
   std::vector<int> candidate_begin_offsets;
   std::vector<int> candidate_end_offsets;
@@ -127,13 +159,24 @@ LookupStatus TokenizeL2RGreedy(
   for (int byte_start = 0; byte_start < token_len;) {
     int byte_end;
     bool found_subword;
+    bool match_is_unknown_character;
     auto status = LongestMatchStartingAt(byte_start, token, suffix_indicator,
-                                         vocab_map, &byte_end, &found_subword);
+                                         split_unknown_characters,
+                                         vocab_map, &byte_end, &found_subword,
+                                         &match_is_unknown_character);
     if (!status.success) return status;
     if (found_subword) {
-      AddWord(token, byte_start, byte_end, suffix_indicator,
-              &candidate_subwords, &candidate_begin_offsets,
-              &candidate_end_offsets);
+      if (match_is_unknown_character) {
+        AddUnknownCharacter(
+            token, byte_start, byte_end,
+            suffix_indicator, use_unknown_token,
+            unknown_token, &candidate_subwords, &candidate_begin_offsets,
+            &candidate_end_offsets);
+      } else {
+        AddWord(token, byte_start, byte_end, suffix_indicator,
+                &candidate_subwords, &candidate_begin_offsets,
+                &candidate_end_offsets);
+      }
       byte_start = byte_end;
     } else {
       return NoTokenFound(token, use_unknown_token, unknown_token, subwords,
@@ -156,9 +199,10 @@ LookupStatus TokenizeL2RGreedy(
 LookupStatus WordpieceTokenize(
     const absl::string_view& token, const int max_bytes_per_token,
     const std::string& suffix_indicator, bool use_unknown_token,
-    const std::string& unknown_token, const WordpieceVocab* vocab_map,
-    std::vector<std::string>* subwords, std::vector<int>* begin_offset,
-    std::vector<int>* end_offset, int* num_word_pieces) {
+    const std::string& unknown_token, bool split_unknown_characters,
+    const WordpieceVocab* vocab_map, std::vector<std::string>* subwords,
+    std::vector<int>* begin_offset, std::vector<int>* end_offset,
+    int* num_word_pieces) {
   int token_len = token.size();
   if (token_len > max_bytes_per_token) {
     begin_offset->push_back(0);
@@ -173,8 +217,9 @@ LookupStatus WordpieceTokenize(
     return LookupStatus::OK();
   }
   return TokenizeL2RGreedy(token, max_bytes_per_token, suffix_indicator,
-                           use_unknown_token, unknown_token, vocab_map,
-                           subwords, begin_offset, end_offset, num_word_pieces);
+                           use_unknown_token, unknown_token,
+                           split_unknown_characters, vocab_map, subwords,
+                           begin_offset, end_offset, num_word_pieces);
 }
 
 }  // namespace text

--- a/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
+++ b/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
@@ -217,8 +217,8 @@ LookupStatus TokenizeL2RGreedy(
 LookupStatus WordpieceTokenize(
     const absl::string_view& token, const int max_bytes_per_token,
     const int max_chars_per_subtoken, const std::string& suffix_indicator,
-    bool use_unknown_token, bool split_unknown_characters,
-    const std::string& unknown_token,
+    bool use_unknown_token, const std::string& unknown_token,
+    bool split_unknown_characters,
     const WordpieceVocab* vocab_map, std::vector<std::string>* subwords,
     std::vector<int>* begin_offset, std::vector<int>* end_offset,
     int* num_word_pieces) {

--- a/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
+++ b/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
@@ -47,14 +47,11 @@ LookupStatus Lookup(int byte_start, int byte_end,
 // 2) is in the vocab OR if split_unknown_characters is true, is a single
 //    UTF8 character.
 // If no match is found, found_match is set to false.
-LookupStatus LongestMatchStartingAt(int byte_start,
-                                    const absl::string_view& token,
-                                    const std::string& suffix_indicator,
-                                    const int max_chars_per_subtoken,
-                                    bool split_unknown_characters,
-                                    const WordpieceVocab* vocab_map,
-                                    int* byte_end, bool* found_match,
-                                    bool* match_is_unknown_character) {
+LookupStatus LongestMatchStartingAt(
+    int byte_start, const absl::string_view& token,
+    const std::string& suffix_indicator, const int max_chars_per_subtoken,
+    bool split_unknown_characters, const WordpieceVocab* vocab_map,
+    int* byte_end, bool* found_match, bool* match_is_unknown_character) {
   *match_is_unknown_character = false;
   *found_match = false;
   const char* token_bytes = token.data();
@@ -135,28 +132,30 @@ void AddWord(const absl::string_view& token, int byte_start, int byte_end,
 
 // Adds a single unknown character subword, found when split_unknown_characters
 // is true.
-void AddUnknownCharacter(
-    const absl::string_view& token, int byte_start, int byte_end,
-    const std::string& suffix_indicator, bool use_unknown_token,
-    const std::string& unknown_token, std::vector<std::string>* subwords,
-    std::vector<int>* begin_offset, std::vector<int>* end_offset) {
+void AddUnknownCharacter(const absl::string_view& token, int byte_start,
+                         int byte_end, const std::string& suffix_indicator,
+                         bool use_unknown_token,
+                         const std::string& unknown_token,
+                         std::vector<std::string>* subwords,
+                         std::vector<int>* begin_offset,
+                         std::vector<int>* end_offset) {
   begin_offset->push_back(byte_start);
   end_offset->push_back(byte_end);
   int len = byte_end - byte_start;
   if (use_unknown_token) {
     if (byte_start > 0) {
-     // Prepend suffix_indicator if the character is within a word.
-     subwords->push_back(::absl::StrCat(suffix_indicator, unknown_token));
+      // Prepend suffix_indicator if the character is within a word.
+      subwords->push_back(::absl::StrCat(suffix_indicator, unknown_token));
     } else {
       subwords->push_back(unknown_token);
     }
   } else {
     if (byte_start > 0) {
-     // Prepend suffix_indicator if the character is within a word.
-     subwords->push_back(::absl::StrCat(
-         suffix_indicator, absl::string_view(token.data() + byte_start, len)));
+      // Prepend suffix_indicator if the character is within a word.
+      subwords->push_back(::absl::StrCat(
+          suffix_indicator, absl::string_view(token.data() + byte_start, len)));
     } else {
-     subwords->emplace_back(token.data(), len);
+      subwords->emplace_back(token.data(), len);
     }
   }
 }
@@ -165,10 +164,9 @@ LookupStatus TokenizeL2RGreedy(
     const absl::string_view& token, const int max_bytes_per_token,
     const int max_chars_per_subtoken, const std::string& suffix_indicator,
     bool use_unknown_token, const std::string& unknown_token,
-    bool split_unknown_characters,
-    const WordpieceVocab* vocab_map, std::vector<std::string>* subwords,
-    std::vector<int>* begin_offset, std::vector<int>* end_offset,
-    int* num_word_pieces) {
+    bool split_unknown_characters, const WordpieceVocab* vocab_map,
+    std::vector<std::string>* subwords, std::vector<int>* begin_offset,
+    std::vector<int>* end_offset, int* num_word_pieces) {
   std::vector<std::string> candidate_subwords;
   std::vector<int> candidate_begin_offsets;
   std::vector<int> candidate_end_offsets;
@@ -177,19 +175,17 @@ LookupStatus TokenizeL2RGreedy(
     int byte_end;
     bool found_subword;
     bool match_is_unknown_character;
-    auto status = LongestMatchStartingAt(byte_start, token, suffix_indicator,
-                                         max_chars_per_subtoken,
-                                         split_unknown_characters,
-                                         vocab_map, &byte_end, &found_subword,
-                                         &match_is_unknown_character);
+    auto status = LongestMatchStartingAt(
+        byte_start, token, suffix_indicator, max_chars_per_subtoken,
+        split_unknown_characters, vocab_map, &byte_end, &found_subword,
+        &match_is_unknown_character);
     if (!status.success) return status;
     if (found_subword) {
       if (match_is_unknown_character) {
-        AddUnknownCharacter(
-            token, byte_start, byte_end,
-            suffix_indicator, use_unknown_token,
-            unknown_token, &candidate_subwords, &candidate_begin_offsets,
-            &candidate_end_offsets);
+        AddUnknownCharacter(token, byte_start, byte_end, suffix_indicator,
+                            use_unknown_token, unknown_token,
+                            &candidate_subwords, &candidate_begin_offsets,
+                            &candidate_end_offsets);
       } else {
         AddWord(token, byte_start, byte_end, suffix_indicator,
                 &candidate_subwords, &candidate_begin_offsets,
@@ -218,10 +214,9 @@ LookupStatus WordpieceTokenize(
     const absl::string_view& token, const int max_bytes_per_token,
     const int max_chars_per_subtoken, const std::string& suffix_indicator,
     bool use_unknown_token, const std::string& unknown_token,
-    bool split_unknown_characters,
-    const WordpieceVocab* vocab_map, std::vector<std::string>* subwords,
-    std::vector<int>* begin_offset, std::vector<int>* end_offset,
-    int* num_word_pieces) {
+    bool split_unknown_characters, const WordpieceVocab* vocab_map,
+    std::vector<std::string>* subwords, std::vector<int>* begin_offset,
+    std::vector<int>* end_offset, int* num_word_pieces) {
   int token_len = token.size();
   if (token_len > max_bytes_per_token) {
     begin_offset->push_back(0);
@@ -235,25 +230,23 @@ LookupStatus WordpieceTokenize(
     }
     return LookupStatus::OK();
   }
-  return TokenizeL2RGreedy(
-    token, max_bytes_per_token, max_chars_per_subtoken, suffix_indicator,
-    use_unknown_token, unknown_token, split_unknown_characters, vocab_map,
-    subwords, begin_offset, end_offset, num_word_pieces);
+  return TokenizeL2RGreedy(token, max_bytes_per_token, max_chars_per_subtoken,
+                           suffix_indicator, use_unknown_token, unknown_token,
+                           split_unknown_characters, vocab_map, subwords,
+                           begin_offset, end_offset, num_word_pieces);
 }
 
 LookupStatus WordpieceTokenize(
     const absl::string_view& token, const int max_bytes_per_token,
     const std::string& suffix_indicator, bool use_unknown_token,
-    const std::string& unknown_token,
-    const WordpieceVocab* vocab_map, std::vector<std::string>* subwords,
-    std::vector<int>* begin_offset, std::vector<int>* end_offset,
-    int* num_word_pieces) {
+    const std::string& unknown_token, const WordpieceVocab* vocab_map,
+    std::vector<std::string>* subwords, std::vector<int>* begin_offset,
+    std::vector<int>* end_offset, int* num_word_pieces) {
   return WordpieceTokenize(token, max_bytes_per_token,
-                           /* max_chars_per_subtoken= */ 0,
-                           suffix_indicator, use_unknown_token, unknown_token,
-                           /* split_unknown_characters= */ false,
-                           vocab_map, subwords, begin_offset, end_offset,
-                           num_word_pieces);
+                           /* max_chars_per_subtoken= */ 0, suffix_indicator,
+                           use_unknown_token, unknown_token,
+                           /* split_unknown_characters= */ false, vocab_map,
+                           subwords, begin_offset, end_offset, num_word_pieces);
 }
 
 }  // namespace text

--- a/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
+++ b/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
@@ -136,7 +136,12 @@ void AddUnknownCharacter(
   end_offset->push_back(byte_end);
   int len = byte_end - byte_start;
   if (use_unknown_token) {
-    subwords->push_back(unknown_token);
+    if (byte_start > 0) {
+     // Prepend suffix_indicator if the character is within a word.
+     subwords->push_back(::absl::StrCat(suffix_indicator, unknown_token));
+    } else {
+      subwords->push_back(unknown_token);
+    }
   } else {
     if (byte_start > 0) {
      // Prepend suffix_indicator if the character is within a word.

--- a/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
+++ b/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
@@ -44,7 +44,8 @@ LookupStatus Lookup(int byte_start, int byte_end,
 
 // Sets byte_end to the longest byte sequence which:
 // 1) is a proper UTF8 sequence
-// 2) is in the vocab
+// 2) is in the vocab OR if split_unknown_characters is true, is a single
+//    UTF8 character.
 // If no match is found, found_match is set to false.
 LookupStatus LongestMatchStartingAt(int byte_start,
                                     const absl::string_view& token,
@@ -124,6 +125,8 @@ void AddWord(const absl::string_view& token, int byte_start, int byte_end,
   end_offset->push_back(byte_end);
 }
 
+// Adds a single unknown character subword, found when split_unknown_characters
+// is true.
 void AddUnknownCharacter(
     const absl::string_view& token, int byte_start, int byte_end,
     const std::string& suffix_indicator, bool use_unknown_token,
@@ -136,7 +139,7 @@ void AddUnknownCharacter(
     subwords->push_back(unknown_token);
   } else {
     if (byte_start > 0) {
-     // Prepend suffix_indicator if the token is within a word.
+     // Prepend suffix_indicator if the character is within a word.
      subwords->push_back(::absl::StrCat(
          suffix_indicator, absl::string_view(token.data() + byte_start, len)));
     } else {

--- a/tensorflow_text/core/kernels/wordpiece_tokenizer.h
+++ b/tensorflow_text/core/kernels/wordpiece_tokenizer.h
@@ -42,9 +42,10 @@ class WordpieceVocab {
 LookupStatus WordpieceTokenize(
     const absl::string_view& token, const int max_bytes_per_token,
     const std::string& suffix_indicator, bool use_unknown_token,
-    const std::string& unknown_token, const WordpieceVocab* vocab_map,
-    std::vector<std::string>* subwords, std::vector<int>* begin_offset,
-    std::vector<int>* end_offset, int* num_word_pieces);
+    const std::string& unknown_token, bool split_unknown_characters,
+    const WordpieceVocab* vocab_map, std::vector<std::string>* subwords,
+    std::vector<int>* begin_offset, std::vector<int>* end_offset,
+    int* num_word_pieces);
 
 }  // namespace text
 }  // namespace tensorflow

--- a/tensorflow_text/core/kernels/wordpiece_tokenizer.h
+++ b/tensorflow_text/core/kernels/wordpiece_tokenizer.h
@@ -43,15 +43,17 @@ LookupStatus WordpieceTokenize(
     const absl::string_view& token, const int max_bytes_per_token,
     const int max_chars_per_subtoken, const std::string& suffix_indicator,
     bool use_unknown_token, const std::string& unknown_token,
+    bool split_unknown_characters,
     const WordpieceVocab* vocab_map, std::vector<std::string>* subwords,
     std::vector<int>* begin_offset, std::vector<int>* end_offset,
     int* num_word_pieces);
 
-// As above but with `max_byteds_per_subtoken` unknown.
+// As above but with `max_bytes_per_subtoken` unknown,
+// and split_unknown_characters=false. (For backwards compatability.)
 LookupStatus WordpieceTokenize(
     const absl::string_view& token, const int max_bytes_per_token,
     const std::string& suffix_indicator, bool use_unknown_token,
-    const std::string& unknown_token, bool split_unknown_characters,
+    const std::string& unknown_token,
     const WordpieceVocab* vocab_map, std::vector<std::string>* subwords,
     std::vector<int>* begin_offset, std::vector<int>* end_offset,
     int* num_word_pieces);

--- a/tensorflow_text/core/kernels/wordpiece_tokenizer.h
+++ b/tensorflow_text/core/kernels/wordpiece_tokenizer.h
@@ -43,20 +43,18 @@ LookupStatus WordpieceTokenize(
     const absl::string_view& token, const int max_bytes_per_token,
     const int max_chars_per_subtoken, const std::string& suffix_indicator,
     bool use_unknown_token, const std::string& unknown_token,
-    bool split_unknown_characters,
-    const WordpieceVocab* vocab_map, std::vector<std::string>* subwords,
-    std::vector<int>* begin_offset, std::vector<int>* end_offset,
-    int* num_word_pieces);
+    bool split_unknown_characters, const WordpieceVocab* vocab_map,
+    std::vector<std::string>* subwords, std::vector<int>* begin_offset,
+    std::vector<int>* end_offset, int* num_word_pieces);
 
 // As above but with `max_bytes_per_subtoken` unknown,
 // and split_unknown_characters=false. (For backwards compatability.)
 LookupStatus WordpieceTokenize(
     const absl::string_view& token, const int max_bytes_per_token,
     const std::string& suffix_indicator, bool use_unknown_token,
-    const std::string& unknown_token,
-    const WordpieceVocab* vocab_map, std::vector<std::string>* subwords,
-    std::vector<int>* begin_offset, std::vector<int>* end_offset,
-    int* num_word_pieces);
+    const std::string& unknown_token, const WordpieceVocab* vocab_map,
+    std::vector<std::string>* subwords, std::vector<int>* begin_offset,
+    std::vector<int>* end_offset, int* num_word_pieces);
 
 }  // namespace text
 }  // namespace tensorflow

--- a/tensorflow_text/core/ops/wordpiece_op.cc
+++ b/tensorflow_text/core/ops/wordpiece_op.cc
@@ -30,6 +30,7 @@ REGISTER_OP("WordpieceTokenizeWithOffsets")
     .Attr("max_bytes_per_word: int")
     .Attr("use_unknown_token: bool")
     .Attr("unknown_token: string")
+    .Attr("split_unknown_characters: bool")
     .Attr("output_row_partition_type: {'row_lengths', 'row_splits'}"
           " = 'row_lengths'")
     .Output("output_values: string")
@@ -65,8 +66,10 @@ REGISTER_OP("WordpieceTokenizeWithOffsets")
     max_bytes_per_word: Max size of input token.
     use_unknown_token: Whether unknown_token should be used.
     unknown_token: The value to use when an unknown token is found.
+    split_unknown_characters: Whether individual unknown unicode characters
+      should be split out as subtokens.
     output_row_partition_type: Indicates what row-partitioning tensor should
-      be returned by the op.  If this is set to 'row_splits', then the 
+      be returned by the op.  If this is set to 'row_splits', then the
       `output_row_lengths` output will contain row-splits instead of
       row-lengths.
 

--- a/tensorflow_text/core/ops/wordpiece_op.cc
+++ b/tensorflow_text/core/ops/wordpiece_op.cc
@@ -30,7 +30,7 @@ REGISTER_OP("WordpieceTokenizeWithOffsets")
     .Attr("max_bytes_per_word: int")
     .Attr("use_unknown_token: bool")
     .Attr("unknown_token: string")
-    .Attr("split_unknown_characters: bool")
+    .Attr("split_unknown_characters: bool = false")
     .Attr("output_row_partition_type: {'row_lengths', 'row_splits'}"
           " = 'row_lengths'")
     .Output("output_values: string")

--- a/tensorflow_text/python/ops/wordpiece_tokenizer.py
+++ b/tensorflow_text/python/ops/wordpiece_tokenizer.py
@@ -42,7 +42,8 @@ class WordpieceTokenizer(TokenizerWithOffsets):
                suffix_indicator='##',
                max_bytes_per_word=100,
                token_out_type=dtypes.int64,
-               unknown_token='[UNK]'):
+               unknown_token='[UNK]',
+               split_unknown_characters=False):
     """Initializes the WordpieceTokenizer.
 
     Args:
@@ -58,6 +59,9 @@ class WordpieceTokenizer(TokenizerWithOffsets):
         `tf.int64`, the `vocab_lookup_table` is used to convert the
         `unknown_token` to an integer. If this is set to `None`,
         out-of-vocabulary tokens are left as is.
+      split_unknown_characters: (optional) Whether to split out single unknown
+        characters as subtokens. If False (default), words containing unknown
+        characters will be treated as single unknown tokens.
     """
     self._vocab_lookup_table = vocab_lookup_table
     self._suffix_indicator = suffix_indicator
@@ -65,6 +69,7 @@ class WordpieceTokenizer(TokenizerWithOffsets):
     self._token_out_type = token_out_type
     self._unknown_token = unknown_token if unknown_token else '[UNK]'
     self._use_unknown_token = True if unknown_token else False
+    self._split_unknown_characters = split_unknown_characters
 
   def tokenize(self, input):  # pylint: disable=redefined-builtin
     """Tokenizes a tensor of UTF-8 string tokens further into subword tokens.
@@ -165,6 +170,7 @@ class WordpieceTokenizer(TokenizerWithOffsets):
               use_unknown_token=self._use_unknown_token,
               max_bytes_per_word=self._max_bytes_per_word,
               unknown_token=self._unknown_token,
+              split_unknown_characters=self._split_unknown_characters,
               **kwargs))
 
       # If ids are desired, look them up in the vocab table. Otherwise just

--- a/tensorflow_text/python/ops/wordpiece_tokenizer_test.py
+++ b/tensorflow_text/python/ops/wordpiece_tokenizer_test.py
@@ -306,24 +306,27 @@ class WordpieceOpTest(ragged_test_util.RaggedTensorTestCase,
           max_bytes_per_word=40,
       ),
       # Test not splitting out unknown characters.
+      # (p and ! are unknown)
       dict(
-          tokens=[[b"nap"]],
-          expected_subwords=[[[b"[UNK]"]]],
+          tokens=[[b"nap", b"hello!me"]],
+          expected_subwords=[[[b"[UNK]"], [b"[UNK]"]]],
           unknown_token="[UNK]",
           vocab=_ENGLISH_VOCAB,
       ),
       # Test splitting out unknown characters.
       dict(
-          tokens=[[b"nap"]],
-          expected_subwords=[[[b"na", b"[UNK]"]]],
+          tokens=[[b"nap", b"hello!me"]],
+          expected_subwords=[
+              [[b"na", b"[UNK]"], [b"hel", b"##lo", b"[UNK]", b"##me"]]],
           unknown_token="[UNK]",
           vocab=_ENGLISH_VOCAB,
           split_unknown_characters=True,
       ),
       # Test splitting out unknown characters, with unknown_token set to None.
       dict(
-          tokens=[[b"nap"]],
-          expected_subwords=[[[b"na", b"##p"]]],
+          tokens=[[b"nap", b"hello!me"]],
+          expected_subwords=[
+              [[b"na", b"##p"], [b"hel", b"##lo", b"##!", b"##me"]]],
           unknown_token=None,
           vocab=_ENGLISH_VOCAB,
           split_unknown_characters=True,

--- a/tensorflow_text/python/ops/wordpiece_tokenizer_test.py
+++ b/tensorflow_text/python/ops/wordpiece_tokenizer_test.py
@@ -305,6 +305,29 @@ class WordpieceOpTest(ragged_test_util.RaggedTensorTestCase,
           vocab=_DEATH_VOCAB,
           max_bytes_per_word=40,
       ),
+      # Test not splitting out unknown characters.
+      dict(
+          tokens=[[b"nap"]],
+          expected_subwords=[[[b"[UNK]"]]],
+          unknown_token="[UNK]",
+          vocab=_ENGLISH_VOCAB,
+      ),
+      # Test splitting out unknown characters.
+      dict(
+          tokens=[[b"nap"]],
+          expected_subwords=[[[b"na", b"[UNK]"]]],
+          unknown_token="[UNK]",
+          vocab=_ENGLISH_VOCAB,
+          split_unknown_characters=True,
+      ),
+      # Test splitting out unknown characters, with unknown_token set to None.
+      dict(
+          tokens=[[b"nap"]],
+          expected_subwords=[[[b"na", b"##p"]]],
+          unknown_token=None,
+          vocab=_ENGLISH_VOCAB,
+          split_unknown_characters=True,
+      ),
   ])
   def testWordPieceOpAndVerifyOffsets(self,
                                       tokens,
@@ -315,7 +338,8 @@ class WordpieceOpTest(ragged_test_util.RaggedTensorTestCase,
                                       use_unknown_token=True,
                                       unknown_token="[UNK]",
                                       token_out_type=dtypes.string,
-                                      max_bytes_per_word=100):
+                                      max_bytes_per_word=100,
+                                      split_unknown_characters=False):
     for horizon in self._FORWARD_COMPATIBILITY_HORIZONS:
       with compat.forward_compatibility_horizon(*horizon):
         tokens_t = ragged_factory_ops.constant(tokens)
@@ -326,6 +350,7 @@ class WordpieceOpTest(ragged_test_util.RaggedTensorTestCase,
             unknown_token=unknown_token,
             token_out_type=token_out_type,
             max_bytes_per_word=max_bytes_per_word,
+            split_unknown_characters=split_unknown_characters,
         )
         subwords_t, begin_t, end_t = tokenizer.tokenize_with_offsets(tokens_t)
         self.assertRaggedEqual(subwords_t, expected_subwords)

--- a/tensorflow_text/python/ops/wordpiece_tokenizer_test.py
+++ b/tensorflow_text/python/ops/wordpiece_tokenizer_test.py
@@ -317,7 +317,7 @@ class WordpieceOpTest(ragged_test_util.RaggedTensorTestCase,
       dict(
           tokens=[[b"nap", b"hello!me"]],
           expected_subwords=[
-              [[b"na", b"[UNK]"], [b"hel", b"##lo", b"[UNK]", b"##me"]]],
+              [[b"na", b"##[UNK]"], [b"hel", b"##lo", b"##[UNK]", b"##me"]]],
           unknown_token="[UNK]",
           vocab=_ENGLISH_VOCAB,
           split_unknown_characters=True,


### PR DESCRIPTION
Currently the presence of an unknown character in a word causes the entire word to be identified as [UNK]. For text encoding, we have found it is better to split out unknown characters as subtokens, and apply oov bucketing later.

E.g. `"hello😀" -> ["hello", "😀"]` or `"hello😀" -> ["hello", "[UNK]"]` instead of `"hello😀" -> ["[UNK]"]`.

This is similar to the approach of sentencepiece, which backs off to outputting single unknown utf8 characters as pieces.

This PR adds this behaviour as an option `split_unknown_characters`, disabled by default for backwards compatibility. 