### PR TITLE
Fix icu_normalization_data linking

### DIFF
--- a/third_party/icu/data/BUILD
+++ b/third_party/icu/data/BUILD
@@ -29,4 +29,5 @@ cc_library(
     name = "icu_normalization_data",
     srcs = ["normalization_data.c"],
     deps = ["@icu//:headers"],
+    alwayslink = 1,
 )


### PR DESCRIPTION
This pull request fix issue https://github.com/tensorflow/text/issues/164 . Without it when you use text as an external bazel target `uprv_getICUData_other` will not be linked.