### PR TITLE
End offset is preserved when an unknonwn token of long size is found.

### DIFF
--- a/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
+++ b/tensorflow_text/core/kernels/wordpiece_tokenizer.cc
@@ -222,12 +222,11 @@ LookupStatus WordpieceTokenize(
     begin_offset->push_back(0);
     *num_word_pieces = 1;
     if (use_unknown_token) {
-      end_offset->push_back(unknown_token.size());
       subwords->emplace_back(unknown_token);
     } else {
       subwords->emplace_back(token);
-      end_offset->push_back(token.size());
     }
+    end_offset->push_back(token_len);
     return LookupStatus::OK();
   }
   return TokenizeL2RGreedy(token, max_bytes_per_token, max_chars_per_subtoken,

--- a/tensorflow_text/python/ops/wordpiece_tokenizer_test.py
+++ b/tensorflow_text/python/ops/wordpiece_tokenizer_test.py
@@ -287,7 +287,7 @@ class WordpieceOpTest(test_util.TensorFlowTestCase, parameterized.TestCase):
           # Explicitly specify the offsets here because the current way of
           # testing offsets would require '[UNK]' to be part of tokens.
           expected_start=[[[0, 3, 4], [0]]],
-          expected_limit=[[[3, 4, 5], [5]]],
+          expected_limit=[[[3, 4, 5], [9]]],
       ),
       # Test the token of death usecase.
       dict(


### PR DESCRIPTION
## [Git Issue 344](https://github.com/tensorflow/text/issues/344)

## Functional
- Before: When one uses the WordPiece tokenizer and sets max_bytes_per_token and use_unknown_token together, information on the length of any token longer than max_bytes_per_token is lost for unknown_token.size() (default: 5).
- Now: The length of the token (not [UNK]) is preserved so that even if the tokenization did not recognize a known token, end-user applications can rely on the offsets.

## Tests
Just found one Python unit-test that needed to be updated.