### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tensorflow_text/python/benchmarks/benchmark_utils.py
+++ b/tensorflow_text/python/benchmarks/benchmark_utils.py
@@ -87,7 +87,7 @@ class OpsBaseBenchmark(benchmark.Benchmark):
                      **kwargs):
     """Runs the benchmark and reports results.
 
-    Arguments:
+    Args:
       fn: Function to be benchmarked.
       iters: Number of iterations to run the benchmark.
       burn_iters: Number of warm-up iterations to run to reach a stable state.

--- a/tensorflow_text/python/keras/layers/todense.py
+++ b/tensorflow_text/python/keras/layers/todense.py
@@ -53,7 +53,7 @@ class ToDense(Layer):   # pylint: disable=g-classes-have-attributes
    [[ 0,  0,  0,  0], [13, 14,  0,  0], [15, 16, 17, 18], [19,  0,  0,  0]]]
   ```
 
-  Arguments:
+  Args:
     pad_value: A value used to pad and fill in the missing values. Should be a
       meaningless value for the input data. Default is '0'.
     mask: A Boolean value representing whether to mask the padded values. If


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420