### PR TITLE
Update `__init__.py`: Added a `__version__` variable

### DIFF
--- a/tensorflow_text/__init__.py
+++ b/tensorflow_text/__init__.py
@@ -76,3 +76,4 @@ _allowed_symbols = [
 ]
 
 remove_undocumented(__name__, _allowed_symbols)
+__version__ = "2.5.0"


### PR DESCRIPTION
Most libraires, including `tensorflow`, `tensorflow_hub`, `numpy`, `pytorch`, `transformers`, etc., have a `__version__` variable. It looks like somehow `tensorflow_text` doesn't have one. Fixing this.