### PR TITLE
Fix load_data function in nmt tutorial

### DIFF
--- a/docs/tutorials/nmt_with_attention.ipynb
+++ b/docs/tutorials/nmt_with_attention.ipynb
@@ -282,7 +282,7 @@
       "outputs": [],
       "source": [
         "def load_data(path):\n",
-        "  text = path_to_file.read_text(encoding='utf-8')\n",
+        "  text = path.read_text(encoding='utf-8')\n",
         "\n",
         "  lines = text.splitlines()\n",
         "  pairs = [line.split('\\t') for line in lines]\n",


### PR DESCRIPTION
load_data() uses the 'path_to_file' global variable when it should
instead use the 'path' argument. Fixed.