### PR TITLE
Improve multi-head attention explanation

### DIFF
--- a/docs/tutorials/transformer.ipynb
+++ b/docs/tutorials/transformer.ipynb
@@ -46,26 +46,26 @@
         "id": "AOpGoE2T-YXS"
       },
       "source": [
-        "\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/text/tutorials/transformer\"\u003e\n",
-        "    \u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003e\n",
-        "    View on TensorFlow.org\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/text/blob/master/docs/tutorials/transformer.ipynb\"\u003e\n",
-        "    \u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003e\n",
-        "    Run in Google Colab\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/text/blob/master/docs/tutorials/transformer.ipynb\"\u003e\n",
-        "    \u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003e\n",
-        "    View source on GitHub\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca href=\"https://storage.googleapis.com/tensorflow_docs/text/docs/tutorials/transformer.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/download_logo_32px.png\" /\u003eDownload notebook\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "\u003c/table\u003e"
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/text/tutorials/transformer\">\n",
+        "    <img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />\n",
+        "    View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/text/blob/master/docs/tutorials/transformer.ipynb\">\n",
+        "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />\n",
+        "    Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/text/blob/master/docs/tutorials/transformer.ipynb\">\n",
+        "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
+        "    View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/text/docs/tutorials/transformer.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
     },
     {
@@ -74,7 +74,7 @@
         "id": "M-f8TnGpE_ex"
       },
       "source": [
-        "This tutorial trains a \u003ca href=\"https://arxiv.org/abs/1706.03762\" class=\"external\"\u003eTransformer model\u003c/a\u003e to translate a [Portuguese to English dataset](https://www.tensorflow.org/datasets/catalog/ted_hrlr_translate#ted_hrlr_translatept_to_en). This is an advanced example that assumes knowledge of [text generation](https://www.tensorflow.org/text/tutorials/text_generation) and [attention](https://www.tensorflow.org/text/tutorials/nmt_with_attention).\n",
+        "This tutorial trains a <a href=\"https://arxiv.org/abs/1706.03762\" class=\"external\">Transformer model</a> to translate a [Portuguese to English dataset](https://www.tensorflow.org/datasets/catalog/ted_hrlr_translate#ted_hrlr_translatept_to_en). This is an advanced example that assumes knowledge of [text generation](https://www.tensorflow.org/text/tutorials/text_generation) and [attention](https://www.tensorflow.org/text/tutorials/nmt_with_attention).\n",
         "\n",
         "The core idea behind the Transformer model is *self-attention*—the ability to attend to different positions of the input sequence to compute a representation of that sequence. Transformer creates stacks of self-attention layers and is explained below in the sections *Scaled dot product attention* and *Multi-head attention*.\n",
         "\n",
@@ -92,7 +92,7 @@
         "\n",
         "After training the model in this notebook, you will be able to input a Portuguese sentence and return the English translation.\n",
         "\n",
-        "\u003cimg src=\"https://www.tensorflow.org/images/tutorials/transformer/attention_map_portuguese.png\" width=\"800\" alt=\"Attention heatmap\"\u003e"
+        "<img src=\"https://www.tensorflow.org/images/tutorials/transformer/attention_map_portuguese.png\" width=\"800\" alt=\"Attention heatmap\">"
       ]
     },
     {
@@ -218,7 +218,7 @@
         "id": "eJxTd6aVnZyh"
       },
       "source": [
-        "## Text tokenization \u0026 detokenization"
+        "## Text tokenization & detokenization"
       ]
     },
     {
@@ -635,7 +635,7 @@
         "id": "vsxEE_-Wa1gF"
       },
       "source": [
-        "\u003cimg src=\"https://www.tensorflow.org/images/tutorials/transformer/scaled_attention.png\" width=\"500\" alt=\"scaled_dot_product_attention\"\u003e\n",
+        "<img src=\"https://www.tensorflow.org/images/tutorials/transformer/scaled_attention.png\" width=\"500\" alt=\"scaled_dot_product_attention\">\n",
         "\n",
         "The attention function used by the transformer takes three inputs: Q (query), K (key), V (value). The equation used to calculate the attention weights is:\n",
         "\n",
@@ -813,7 +813,7 @@
         "id": "fz5BMC8Kaoqo"
       },
       "source": [
-        "\u003cimg src=\"https://www.tensorflow.org/images/tutorials/transformer/multi_head_attention.png\" width=\"500\" alt=\"multi-head attention\"\u003e\n",
+        "<img src=\"https://www.tensorflow.org/images/tutorials/transformer/multi_head_attention.png\" width=\"500\" alt=\"multi-head attention\">\n",
         "\n",
         "\n",
         "Multi-head attention consists of four parts:\n",
@@ -833,7 +833,7 @@
         "\n",
         "The `scaled_dot_product_attention` defined above is applied to each head (broadcasted for efficiency). An appropriate mask must be used in the attention step.  The attention output for each head is then concatenated (using `tf.transpose`, and `tf.reshape`) and put through a final `Dense` layer.\n",
         "\n",
-        "Instead of one single attention head, Q, K, and V are split into multiple heads because it allows the model to jointly attend to information at different positions from different representational spaces. After the split each head has a reduced dimensionality, so the total computation cost is the same as a single head attention with full dimensionality."
+        "Instead of one single attention head, Q, K, and V are split into multiple heads because it allows the model to jointly attend to information from different representation subspaces at different positions. After the split each head has a reduced dimensionality, so the total computation cost is the same as a single head attention with full dimensionality."
       ]
     },
     {
@@ -976,7 +976,7 @@
         "id": "yScbC0MUH8dS"
       },
       "source": [
-        "\u003cimg src=\"https://www.tensorflow.org/images/tutorials/transformer/transformer.png\" width=\"600\" alt=\"transformer\"\u003e"
+        "<img src=\"https://www.tensorflow.org/images/tutorials/transformer/transformer.png\" width=\"600\" alt=\"transformer\">"
       ]
     },
     {
@@ -1751,7 +1751,7 @@
         "  train_loss.reset_states()\n",
         "  train_accuracy.reset_states()\n",
         "\n",
-        "  # inp -\u003e portuguese, tar -\u003e english\n",
+        "  # inp -> portuguese, tar -> english\n",
         "  for (batch, (inp, tar)) in enumerate(train_batches):\n",
         "    train_step(inp, tar)\n",
         "\n",
@@ -1960,7 +1960,7 @@
       "source": [
         "def plot_attention_head(in_tokens, translated_tokens, attention):\n",
         "  # The plot is of the attention when a token was generated.\n",
-        "  # The model didn't generate `\u003cSTART\u003e` in the output. Skip it.\n",
+        "  # The model didn't generate `<START>` in the output. Skip it.\n",
         "  translated_tokens = translated_tokens[1:]\n",
         "\n",
         "  ax = plt.gca()\n",


### PR DESCRIPTION
Direct quote from the paper. I think 'subspaces' provides intuition over the split and should not be omitted. When I was going through the tutorial myself I didn't understand the explanation until I saw the word 'subspaces' in the original research paper. The current line in the tutorial seems like it was lifted anyways with a small rephrase so I was wondering why the crucial prefix 'sub' was omitted. Hope this gets added so that it may clear up confusion for future learners going through the tutorial. Cheers. 

P.S Not sure why there are unicode changes though. They were not intended. My contribution is only in change to the explanation of Multi-Head Attention in the transformer notebook tutorial. 