### PR TITLE
Update nmt_with_attention.ipynb

### DIFF
--- a/docs/tutorials/nmt_with_attention.ipynb
+++ b/docs/tutorials/nmt_with_attention.ipynb
@@ -81,7 +81,7 @@
         "  * Working with tensors directly \n",
         "  * Writing custom `keras.Model`s and `keras.layers`\n",
         "\n",
-        "While this architecture is somewhat outdated it is still a very useful project to work through to get a deeper understanding of attention mechanisms (before going on to [Transformers](transformers.ipynb)).\n",
+        "While this architecture is somewhat outdated it is still a very useful project to work through to get a deeper understanding of attention mechanisms (before going on to [Transformers](transformer.ipynb)).\n",
         "\n",
         "After training the model in this notebook, you will be able to input a Spanish sentence, such as \"*¿todavia estan en casa?*\", and return the English translation: \"*are you still at home?*\"\n",
         "\n",


### PR DESCRIPTION
Fix dead link https://github.com/tensorflow/text/blob/master/docs/tutorials/transformers.ipynb to https://github.com/tensorflow/text/blob/master/docs/tutorials/transformer.ipynb

Link referenced at https://www.tensorflow.org/text/tutorials/nmt_with_attention