### PR TITLE
Add `flat_hash_map` dependency to `tf_cc_library`

### DIFF
--- a/tensorflow_text/core/kernels/BUILD
+++ b/tensorflow_text/core/kernels/BUILD
@@ -436,7 +436,6 @@ tf_cc_library(
     ],
     deps = [
         "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/meta:type_traits",
         "@com_google_absl//absl/strings",

--- a/tensorflow_text/tftext.bzl
+++ b/tensorflow_text/tftext.bzl
@@ -113,6 +113,7 @@ def tf_cc_library(
         alwayslink = 1
     # These are "random" deps likely needed by each library (http://b/142433427)
     oss_deps = [
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/strings:cord",
         "@com_google_absl//absl/time",
     ]


### PR DESCRIPTION
Many kernels depend on this. Note that the dependency was NOT MOVED. It was ADDED.

The removed line only removes a resulting duplicate dependency.

Please let me know if this should be added somewhere else instead.

Edit: reference #717 