### PR TITLE
Improve run_tests.sh

### DIFF
--- a/oss_scripts/run_tests.sh
+++ b/oss_scripts/run_tests.sh
@@ -4,4 +4,4 @@ set -x  # print commands as they are executed
 set -e  # fail and exit on any command erroring
 
 ./oss_scripts/configure.sh
-bazel test --test_output=errors tensorflow_text:all
+bazel test --test_output=errors --keep_going --jobs=1 tensorflow_text:all


### PR DESCRIPTION
The --keep_going flag will make bazel run all tests instead of stopping at the first failure.

The --jobs=1 flag will prevent tests from running in parallel. This is required for some tests to
pass if a GPU is present (and probably in other situations).