### PR TITLE
Adding copy to clipboard and cd step to "Build from source steps"

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,8 @@ to do with Homebrew.
 1. [build and install TensorFlow](https://www.tensorflow.org/install/source).
 1. Clone the TF Text repo:
    ```Shell
-   git clone https://github.com/tensorflow/text.git && cd text
+   git clone https://github.com/tensorflow/text.git
+   cd text
    ```
 1. Run the build script to create a pip package:
    ```Shell


### PR DESCRIPTION
In "Build from source steps" I added the `cd text` command after `git pull ...` and enabled the other commands to be copied to clipboard.