### PR TITLE
📦️ Fix macOS packaging

### DIFF
--- a/oss_scripts/pip_package/setup.py
+++ b/oss_scripts/pip_package/setup.py
@@ -73,8 +73,8 @@ setup(
     cmdclass={'install': InstallPlatlib},
     distclass=BinaryDistribution,
     install_requires=[
-        'tensorflow>=2.8.0, <2.9',
-        'tensorflow-macos>=2.7.0, <2.8.0; platform_machine == "arm64" and platform_system == "Darwin"',
+        'tensorflow>=2.8.0, <2.9; platform_machine != "arm64" or platform_system != "Darwin"',
+        'tensorflow-macos>=2.8.0, <2.9; platform_machine == "arm64" and platform_system == "Darwin"',
         'tensorflow_hub>=0.8.0',
     ],
     extras_require={


### PR DESCRIPTION
The TensorFlow Text package requires use of a matching minor version of TensorFlow. In order to support Apple Silicon macs, Tensorflow Text chooses between the `tensorflow` and `tensorflow-macos` packages automatically based on system architecture. However, I believe that commit a7e1b5b6cdc4d35eb2849f83eaa670bcc7faf10d accidentally wiped out this logic. Additionally, this commit failed to increment the minor version of the `tensorflow-macos` dependency.

This typically isn't a problem for users installing TensorFlow Text using `pip` on non-Apple Silicon devices, since `pip` just tries to find the best set of packages for the current system. However, this _is_ a problem for package managers like Poetry, which create a deterministic lock file allowing a similar set of dependencies to be installed across different systems, modulo any architectural differences. Since Poetry needs to resolve a combination of dependencies that will work for _any_ system, it eagerly tries to identify a version of `tensorflow-macos` that will work on Apple Silicon devices. However, since the minor versions of the `tensorflow` and `tensorflow-macos` dependencies don't match, it's unable to find an appropriate version of `keras` that both can use. As a result, installing `tensorflow-text (>=2.8.0)` using Poetry is currently impossible.

These changes restore the logic to automatically select between `tensorflow` and `tensorflow-macos` based on platform and architecture identifiers, and bump the version of the `tensorflow-macos` dependency to match the minor version of `tensorflow` and `tensorflow-text`.