### PR TITLE
Only export tensorflow symbols from shared libs.

### DIFF
--- a/tensorflow_text/exported_symbols.lds
+++ b/tensorflow_text/exported_symbols.lds
@@ -1,0 +1,1 @@
+*tensorflow*

--- a/tensorflow_text/tftext.bzl
+++ b/tensorflow_text/tftext.bzl
@@ -40,6 +40,15 @@ def py_tf_text_library(
         library_name = name + "_cc"
         native.cc_library(
             name = library_name,
+            linkopts = select({
+                "@org_tensorflow//tensorflow:macos": [
+                    "-Wl,-exported_symbols_list,$(location //tensorflow_text:exported_symbols.lds)",
+                ],
+                "@org_tensorflow//tensorflow:windows": [],
+                "//conditions:default": [
+                    "-Wl,--version-script,$(location //tensorflow_text:version_script.lds)",
+                ],
+            }),
             srcs = cc_op_defs,
             copts = select({
                 # Android supports pthread natively, -pthread is not needed.
@@ -47,7 +56,10 @@ def py_tf_text_library(
                 "//conditions:default": ["-pthread"],
             }),
             alwayslink = 1,
-            deps = cc_op_kernels + select({
+            deps = [
+                "//tensorflow_text:version_script.lds",
+                "//tensorflow_text:exported_symbols.lds",
+            ] + cc_op_kernels + select({
                 "@org_tensorflow//tensorflow:mobile": [
                     "@org_tensorflow//tensorflow/core:portable_tensorflow_lib_lite",
                 ],

--- a/tensorflow_text/version_script.lds
+++ b/tensorflow_text/version_script.lds
@@ -1,0 +1,6 @@
+tensorflow_text {
+  global:
+    *tensorflow*;
+  local:
+    *;
+};


### PR DESCRIPTION
Intended to address https://github.com/tensorflow/text/issues/786.

The tensorflow-text symbols appear to be consistently located in the tensorflow::text namespace. Exporting other symbols (e.g., from protobuf, absl, etc.) can create conflicts when other packages depend on different versions of those libs.

The linker version scripts apply to C++ mangled symbols. In the interest of portability, this PR exposes only symbols matching `*tensorflow*`.