### PR TITLE
Fix typo error text.WordpieceTokenizer

### DIFF
--- a/docs/guide/subwords_tokenizer.ipynb
+++ b/docs/guide/subwords_tokenizer.ipynb
@@ -245,7 +245,7 @@
       "source": [
         "## Generate the vocabulary\n",
         "\n",
-        "This section generates a wordpiece vocabulary from a dataset. If you already have a vocabulary file and just want to see how to build a `text.BertTokenizer` or `text.Wordpiece` tokenizer with it then you can skip ahead to the [Build the tokenizer](#build_the_tokenizer) section."
+        "This section generates a wordpiece vocabulary from a dataset. If you already have a vocabulary file and just want to see how to build a `text.BertTokenizer` or `text.WordpieceTokenizer` tokenizer with it then you can skip ahead to the [Build the tokenizer](#build_the_tokenizer) section."
       ]
     },
     {


### PR DESCRIPTION
Replaced `text.Wordpiece` with correct API name `text.WordpieceTokenizer`
Right link https://www.tensorflow.org/text/api_docs/python/text/WordpieceTokenizer