### PR TITLE
fix typo(GlobalAveragePoling1D to GlobalAveragePooling1D in text/docs/tutorials/nmt_with_attention.ipynb)

### DIFF
--- a/docs/tutorials/nmt_with_attention.ipynb
+++ b/docs/tutorials/nmt_with_attention.ipynb
@@ -760,7 +760,7 @@
         "### The attention head\n",
         "\n",
         "The decoder uses attention to selectively focus on parts of the input sequence.\n",
-        "The attention takes a sequence of vectors as input for each example and returns an \"attention\" vector for each example. This attention layer is similar to a `layers.GlobalAveragePoling1D` but the attention layer performs a _weighted_ average.\n",
+        "The attention takes a sequence of vectors as input for each example and returns an \"attention\" vector for each example. This attention layer is similar to a `layers.GlobalAveragePooling1D` but the attention layer performs a _weighted_ average.\n",
         "\n",
         "Let's look at how this works:\n",
         "\n",


### PR DESCRIPTION
in text/docs/tutorials/nmt_with_attention.ipynb
GlobalAveragePoling1D to GlobalAveragePooling1D