### PR TITLE
Correct explanation: meaning of attention weights

### DIFF
--- a/docs/tutorials/transformer.ipynb
+++ b/docs/tutorials/transformer.ipynb
@@ -807,7 +807,7 @@
         "id": "FiqETnhCkoXh"
       },
       "source": [
-        "As the softmax normalization is done on K, its values decide the amount of importance given to Q.\n",
+        "As the softmax normalization is done along the dimension for keys, the attention values decide the amount of importance given to the keys for each query.\n",
         "\n",
         "The output represents the multiplication of the attention weights and the V (value) vector. This ensures that the tokens you want to focus on are kept as-is and the irrelevant tokens are flushed out."
       ]


### PR DESCRIPTION
The current explanation makes it seem as though the attention weights
show the importance of queries for each key, but instead the opposite is
true: we normalize along the key dimension to show distribution of
importance of keys for any given query.