### PR TITLE
Fixing the incorrect link in TF doc

### DIFF
--- a/docs/guide/unicode.ipynb
+++ b/docs/guide/unicode.ipynb
@@ -129,7 +129,7 @@
         "id": "jsMPnjb6UDJ1"
       },
       "source": [
-        "If you use Python to construct strings, note that [string literals](https://docs.python.org/3/reference/lexical_analysis.html) are Unicode-encoded by default."
+        "If you use Python to construct strings, note that [string literals](https://docs.python.org/3/reference/lexical_analysis.html#literals) are Unicode-encoded by default."
       ]
     },
     {


### PR DESCRIPTION
Added the correct link for string literals.