### PR TITLE
Fixed TF branch name from where TF configuration is to be pulled

### DIFF
--- a/oss_scripts/prepare_tf_dep.sh
+++ b/oss_scripts/prepare_tf_dep.sh
@@ -20,6 +20,9 @@ sed -i $ext "s/project_version = 'REPLACE_ME'/project_version = '${tf_version}'/
 # update __version__
 sed -i $ext "s/__version__ = .*\$/__version__ = \"${tf_version}\"/" tensorflow_text/__init__.py
 
+# Update TF branch to download .bazelrc and .bazelversion from, according to the TF which is installed
+sed -E -i 's|curl https://raw.githubusercontent.com/tensorflow/tensorflow/master|curl https://raw.githubusercontent.com/tensorflow/tensorflow/v${tf_version}|' oss_scripts/configure.sh
+
 # Get commit sha of installed tensorflow
 # For some unknown reason this now needs to be split into two commands on Windows
 short_commit_sha=$($installed_python -c 'import tensorflow as tf; print(tf.__git_version__)' | tail -1)

--- a/oss_scripts/run_build.sh
+++ b/oss_scripts/run_build.sh
@@ -10,6 +10,11 @@ if [[ $osname == "Darwin" ]]; then
   export CC_OPT_FLAGS='-mavx'
 fi
 
+# Set tensorflow version
+if [[ $osname != "Darwin" ]] || [[ ! $(sysctl -n machdep.cpu.brand_string) =~ "Apple" ]]; then
+  source oss_scripts/prepare_tf_dep.sh
+fi
+
 # Run configure.
 source oss_scripts/configure.sh
 
@@ -21,11 +26,6 @@ if [ "$installed_bazel_version" != "$tf_bazel_version" ]; then
   echo "Version $tf_bazel_version should be installed, but found version ${installed_bazel_version}."
   echo "Run oss_scripts/install_bazel.sh or manually install the correct version."
   exit 1
-fi
-
-# Set tensorflow version
-if [[ $osname != "Darwin" ]] || [[ ! $(sysctl -n machdep.cpu.brand_string) =~ "Apple" ]]; then
-  source oss_scripts/prepare_tf_dep.sh
 fi
 
 # Build the pip package.


### PR DESCRIPTION
This fix is needed to use the correct TF branch from where TF's configuration files (.bazelrc and .bazelversion ) are to be pulled.
When I built TF text 2.9 using TF 2.9.1 , the import of TF text failed with following error -
```/opt/conda/envs/opence-conda-env-py3.9-cuda-openmpi-11.4/lib/python3.9/site-packages/tensorflow_text/python/ops/_regex_split_ops.so - undefined symbol: _ZN10tensorflow6StatusC1ENS_5error4CodeESt17basic_string_viewIcSt11char_traitsIcEEOSt6vectorINS_10StackFrameESaIS8_EE```

After investigating the issue, I found that TF text 2.9.0 which I was building was using -std=c++17 as cxxopts and TF 2.9.1 was built using c++14. This is because TF text downloads `.bazelrc` and `.bazelversion` from the master branch of TF which is recently updated to have c++17 as default C++ standard.
So, as a fix, instead of master branch, we should use TF's respective version branch as that of the one we have installed as a dependency while building TF text.