### PR TITLE
Bug fix - Non TPU env

### DIFF
--- a/docs/tutorials/bert_glue.ipynb
+++ b/docs/tutorials/bert_glue.ipynb
@@ -221,7 +221,7 @@
       "source": [
         "import os\n",
         "\n",
-        "if os.environ['COLAB_TPU_ADDR']:\n",
+        "if os.environ.get('COLAB_TPU_ADDR'):\n",
         "  cluster_resolver = tf.distribute.cluster_resolver.TPUClusterResolver(tpu='')\n",
         "  tf.config.experimental_connect_to_cluster(cluster_resolver)\n",
         "  tf.tpu.experimental.initialize_tpu_system(cluster_resolver)\n",


### PR DESCRIPTION
If TPU acceleration is not available, os.environ['COLAB_TPU_ADDR'] fails (keyError). 
Fixed it to os.environ.get('COLAB_TPU_ADDR'), which returns NoneType and then continue to look for GPU or raise ValueError