### PR TITLE
Fix '_normalize_with_offsets_helper' when input tensor has rank == 0

### DIFF
--- a/tensorflow_text/python/ops/fast_bert_normalizer.py
+++ b/tensorflow_text/python/ops/fast_bert_normalizer.py
@@ -152,8 +152,7 @@ class FastBertNormalizer(module.Module):
       if rank == 0:
         normalized_texts, offsets = self._normalize_with_offsets_helper(
             array_ops.stack([input]), get_offsets)
-        return (normalized_texts.values,
-                offsets.values if get_offsets else None)
+        return (normalized_texts, offsets if get_offsets else None)
 
       elif rank > 1:
         if not ragged_tensor.is_ragged(input):


### PR DESCRIPTION
Currently, when trying to tokenize using the FastBertTokenizer gives the following error error:
```python
from tensorflow_text import FastBertTokenizer
import tensorflow as tf
vocab = ['they', "##'", '##re', 'the', 'great', '##est', '[UNK]']
tokenizer = FastBertTokenizer(vocab=vocab)
text_inputs = tf.constant('greatest'.encode('utf-8'))
tokenizer.tokenize(text_inputs)

AttributeError: 'tensorflow.python.framework.ops.EagerTensor' object has no attribute 'values'
```

This happens when the input tensor has rank == 0