### PR TITLE
Create CODEOWNERS file so docs PRs are directed to the tensorflow/docs team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# https://help.github.com/articles/about-codeowners/
+# Last matching pattern takes precedence.
+
+# Automatically request reviews from tensorflow docs team.
+docs/  @tensorflow/docs-team


### PR DESCRIPTION
Can you give @tensorflow/docs write access to the repository so that the automatic reviews work?