### PR TITLE
Read correct bazel version during build

### DIFF
--- a/oss_scripts/run_build.sh
+++ b/oss_scripts/run_build.sh
@@ -16,7 +16,7 @@ source oss_scripts/configure.sh
 
 # Verify correct version of Bazel
 installed_bazel_version=$(bazel version | grep label | sed -e 's/.*: //')
-tf_bazel_version=$(cat .bazelversion)
+tf_bazel_version=$(head -1 .bazelversion)
 if [ "$installed_bazel_version" != "$tf_bazel_version" ]; then
   echo "Incorrect version of Bazel installed."
   echo "Version $tf_bazel_version should be installed, but found version ${installed_bazel_version}."


### PR DESCRIPTION
### Problem
Running `oss_build/run_build.sh` gave the following error;
```
++ cat .bazelversion
+ tf_bazel_version='5.3.0
# NOTE: Update Bazel version in tensorflow/tools/ci_build/release/common.sh.oss'
+ '[' 5.3.0 '!=' '5.3.0
# NOTE: Update Bazel version in tensorflow/tools/ci_build/release/common.sh.oss' ']'
+ echo 'Incorrect version of Bazel installed.'
Incorrect version of Bazel installed.
```

A comment was recently added to https://github.com/tensorflow/tensorflow/blob/master/.bazelversion, which was then being read in via `cat` as part of the version. This looks at only the first line

```
++ head -1 .bazelversion
+ tf_bazel_version=5.3.0
+ '[' 5.3.0 '!=' 5.3.0 ']'
```