### PR TITLE
Fix build breakage by removing line wrongly added

### DIFF
--- a/tensorflow_text/core/kernels/BUILD
+++ b/tensorflow_text/core/kernels/BUILD
@@ -926,7 +926,6 @@ tf_cc_library(
     ],
     deps = [
         ":sentence_fragmenter_v2_kernel_template",
-        "//third_party/absl/synchronization",
         # lite/kernels/shim:tf_op_shim tensorflow dep,
     ],
 )


### PR DESCRIPTION
This line was incorrectly added in the previous commit, so remove it to restore a working build.