### PR TITLE
Remove unnecessary install from transformer.ipynb

### DIFF
--- a/docs/tutorials/transformer.ipynb
+++ b/docs/tutorials/transformer.ipynb
@@ -223,7 +223,6 @@
       "source": [
         "# Install the most re version of TensorFlow to use the improved\n",
         "# masking support for `tf.keras.layers.MultiHeadAttention`.\n",
-        "!apt install --allow-change-held-packages libcudnn8=8.1.0.77-1+cuda11.2\n",
         "!pip uninstall -y -q tensorflow keras tensorflow-estimator tensorflow-text\n",
         "!pip install protobuf~=3.20.3\n",
         "!pip install -q tensorflow_datasets\n",


### PR DESCRIPTION
The code still runs as intended without the --allow-change-held-packages libcudnn8=8.1.0.77-1+cuda11.2 install, and keeping it seems to cause errors with GPU acceleration and larger datasets.