### PR TITLE
Update TensorFlow to latest release which supports Cuda 12

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,12 +70,10 @@ http_archive(
 
 http_archive(
     name = "org_tensorflow",
-    patch_args = ["-p1"],
-    patches = ["//third_party/tensorflow:tf.patch"],
-    strip_prefix = "tensorflow-2.12.0",
+    strip_prefix = "tensorflow-1cb1a030a62b169d90d34c747ab9b09f332bf905",
     sha256 = "af0584df1a4e28763c32c218b39f8c4f3784fabb6a8859b00c02d743864dc191",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/v2.12.0.zip"
+        "https://github.com/tensorflow/tensorflow/archive/1cb1a030a62b169d90d34c747ab9b09f332bf905.zip"
     ],
 )
 

--- a/oss_scripts/configure.sh
+++ b/oss_scripts/configure.sh
@@ -48,10 +48,10 @@ else
     if [[ x"$(arch)" == x"arm64" ]]; then
       pip install tensorflow-macos==2.9.0
     else
-      pip install tensorflow==2.12.0
+      pip install tensorflow==2.13.0
     fi
   else
-    pip install tensorflow==2.12.0
+    pip install tensorflow==2.13.0
   fi
 fi
 

--- a/oss_scripts/pip_package/setup.py
+++ b/oss_scripts/pip_package/setup.py
@@ -32,7 +32,7 @@ from setuptools.command.install import install
 from setuptools.dist import Distribution
 
 project_name = 'tensorflow-text'
-project_version = '2.12.0'
+project_version = '2.13.0'
 
 
 class BinaryDistribution(Distribution):
@@ -74,18 +74,18 @@ setup(
     distclass=BinaryDistribution,
     install_requires=[
         (
-            'tensorflow>=2.12.0, <2.13; platform_machine != "arm64" or'
+            'tensorflow>=2.13.0, <=2.13; platform_machine != "arm64" or'
             ' platform_system != "Darwin"'
         ),
         (
-            'tensorflow-macos>=2.12.0, <2.13; platform_machine == "arm64" and'
+            'tensorflow-macos>=2.12.0, <=2.13; platform_machine == "arm64" and'
             ' platform_system == "Darwin"'
         ),
         'tensorflow_hub>=0.13.0',
     ],
     extras_require={
         'tensorflow_cpu': [
-            'tensorflow-cpu>=2.12.0, <2.13',
+            'tensorflow-cpu>=2.13.0, <=2.13',
         ],
         'tests': [
             'absl-py',

--- a/tensorflow_text/__init__.py
+++ b/tensorflow_text/__init__.py
@@ -110,4 +110,4 @@ tflite_registrar.SELECT_TFTEXT_OPS = [
 ]
 
 remove_undocumented(__name__, _allowed_symbols)
-__version__ = "2.12.0"
+__version__ = "2.13.0"


### PR DESCRIPTION
I'm working on an Aarch64 platform where there are no wheels for tensorflow text and I have to build from source.

Right now the source build seems broken because the tf.patch does not apply: #1195

Beyond this I had to upgrade to TensorFlow 2.13 to align with Tensorflow expected protobuf version.