### PR TITLE
Update api_overview.md

### DIFF
--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -40,7 +40,7 @@ classes for building SOTA NLP models including `nlp.layers`, `nlp.losses`,
 You can install the package with `pip`:
 
 ```
-$ pip install tensorflow-models-official  # For the latest release
+$ pip install tf-models-official  # For the latest release
 $ #or
 $ pip install tf-models-nightly # For the nightly build
 ```


### PR DESCRIPTION
`pip install tensorflow-models-official` does not exist, replaced with `pip install tf-models-official`