### PR TITLE
Add custom build folder

### DIFF
--- a/build_pip_package.py
+++ b/build_pip_package.py
@@ -53,11 +53,15 @@ def main(output_dir=None):
     old_cwd = os.getcwd()
     os.chdir(temp_dir)
     try:
-        python_cmd = shutil.which("python3") or shutil.which("python")
-        if python_cmd is None:
+        if shutil.which('python3'):
+            python_cmd = 'python3'
+        elif shutil.which('python'):
+            python_cmd = 'python'
+        else:
             print("Python not found in PATH.", file=sys.stderr)
             sys.exit(1)
 
+        print(python_cmd, setup_script, "bdist_wheel", "--universal")
         subprocess.run([python_cmd, setup_script, "bdist_wheel", "--universal"], check=True)
         # Copy generated wheel(s) to output directory
         dist_dir = os.path.join(temp_dir, "dist")

--- a/oss_scripts/configure.sh
+++ b/oss_scripts/configure.sh
@@ -76,11 +76,9 @@ if [[ "$TF_VERSION" == *"rc"* ]]; then
   REQUIREMENTS_EXTRA_FLAGS="$REQUIREMENTS_EXTRA_FLAGS --pre"
 fi
 
-pip-compile $REQUIREMENTS_EXTRA_FLAGS oss_scripts/pip_package/requirements.in
-# bazel run //oss_scripts/pip_package:requirements.update -- $REQUIREMENTS_EXTRA_FLAGS
+bazel run //oss_scripts/pip_package:requirements.update -- $REQUIREMENTS_EXTRA_FLAGS
 
-TF_ABIFLAG=$(python3 oss_scripts/pip_package/tensorflow_build_info.py --abi)
-# TF_ABIFLAG=$(bazel run //oss_scripts/pip_package:tensorflow_build_info -- abi)
+TF_ABIFLAG=$(bazel run //oss_scripts/pip_package:tensorflow_build_info -- abi)
 SHARED_LIBRARY_NAME="libtensorflow_framework.so.2"
 if is_macos; then
   SHARED_LIBRARY_NAME="libtensorflow_framework.2.dylib"

--- a/oss_scripts/prepare_tf_dep.sh
+++ b/oss_scripts/prepare_tf_dep.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -e  # fail and exit on any command erroring
+set -e  # fail and exit on any command erroring
 
 if (which python3) | grep -q "python3"; then
   installed_python="python3"
@@ -14,8 +14,7 @@ if [[ "${osname}" == "darwin" ]]; then
 fi
 
 # Update setup.nightly.py with current tf version.
-# tf_version=$(bazel run //oss_scripts/pip_package:tensorflow_build_info -- version)
-tf_version=$(python3 oss_scripts/pip_package/tensorflow_build_info.py --version)
+tf_version=$(bazel run //oss_scripts/pip_package:tensorflow_build_info -- version)
 echo "Updating setup.nightly.py to version $tf_version"
 sed -i $ext "s/project_version = '.*'/project_version = '${tf_version}'/" oss_scripts/pip_package/setup.nightly.py
 # Update __version__.
@@ -24,8 +23,7 @@ sed -i $ext "s/__version__ = .*\$/__version__ = \"${tf_version}\"/" tensorflow_t
 
 # Get git commit sha of installed tensorflow.
 echo "Querying commit SHA"
-# short_commit_sha=$(bazel run  //oss_scripts/pip_package:tensorflow_build_info -- git_version)
-short_commit_sha=$(python3 oss_scripts/pip_package/tensorflow_build_info.py --git_version)
+short_commit_sha=$(bazel run  //oss_scripts/pip_package:tensorflow_build_info -- git_version)
 if [[ "$short_commit_sha" == "unknown" ]]; then
   # Some nightly builds report "unknown" for tf.__git_version.
   echo 'TF git version "unknown", assuming nightly.'

--- a/oss_scripts/run_build.sh
+++ b/oss_scripts/run_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -e  # fail and exit on any command erroring
+set -e  # fail and exit on any command erroring
 
 osname="$(uname -s | tr 'A-Z' 'a-z')"
 
@@ -19,7 +19,6 @@ if [[ $osname != "darwin" ]] || [[ ! $(sysctl -n machdep.cpu.brand_string) =~ "A
 fi
 
 # Build the pip package.
-echo "RUNNING THIS NOW!!!!"
 bazel run ${BUILD_ARGS[@]} --enable_runfiles //oss_scripts/pip_package:build_pip_package -- "$(realpath .)"
 
 if [ -n "${AUDITWHEEL_PLATFORM}" ]; then


### PR DESCRIPTION
Allows installation with `pip install .` and installation from other projects using `tensorflow-text @ git+https://github.com/tensorflow/text` dependency. Important for operating systems where tensorflow-text has no released wheels including Windows. 

Was broken because `pip install .` tried to create a folder "build" in the same folder as file "BUILD" which fails on case-insensitive operating systems like Windows