### PR TITLE
Exclude stubdata and i18n BUILD.bazel from ICU 77 repository archive

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,8 @@ custom_http_archive(
     exclude = [
         # Build file does not contain all required targets.
         "icu4c/source/common/BUILD.bazel",
+        "icu4c/source/stubdata/BUILD.bazel",
+        "icu4c/source/i18n/BUILD.bazel",
     ],
     files = {
         "BUILD.bazel": "//third_party/icu:BUILD.bzl",

--- a/third_party/icu/BUILD.bzl
+++ b/third_party/icu/BUILD.bzl
@@ -55,6 +55,7 @@ cc_library(
     ),
     hdrs = glob([
         "icu4c/source/common/*.h",
+        "icu4c/source/stubdata/*.h",
     ]),
     copts = [
         "-DU_COMMON_IMPLEMENTATION",


### PR DESCRIPTION
In ICU 77, BUILD.bazel files were added upstream under `icu4c/source/stubdata/` and `icu4c/source/i18n/`. Because `custom_http_archive` only excluded `icu4c/source/common/BUILD.bazel`, Bazel treated `icu4c/source/stubdata/` as a separate package, preventing `glob(["icu4c/source/stubdata/*.cpp"])` in `//third_party/icu:BUILD.bzl` from matching `stubdata.cpp`. Consequently, `U_ICUDATA_ENTRY_POINT` (`icudt77_dat`) was omitted from the build, resulting in undefined symbol errors upon importing `tensorflow_text` on systems without ICU 77.

Excluding `stubdata/BUILD.bazel` and `i18n/BUILD.bazel` and including `stubdata/*.h` in `hdrs` allows `stubdata.cpp` to be cleanly compiled into `icuuc`, resolving `icudt77_dat`.

Fixes #1541